### PR TITLE
Fix brand wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
   </nav>
   <header class="hero">
     <div class="hero-content">
-      <h1>Welcome to Iron Vest</h1>
+      <h1>Welcome to Iron&nbsp;Vest</h1>
       <p>Explore how artificial intelligence can transform our company.</p>
       <a href="dashboard/index.html" class="cta-button">Launch Dashboard</a>
     </div>
@@ -96,7 +96,7 @@
   </main>
   <footer class="site-footer">
     <div class="container">
-      <p>&copy; 2024 Iron Vest. All rights reserved.</p>
+      <p>&copy; 2024 Iron&nbsp;Vest. All rights reserved.</p>
     </div>
   </footer>
 </body>

--- a/style.css
+++ b/style.css
@@ -25,6 +25,7 @@ nav a.logo {
   color: #fff;
   text-decoration: none;
   margin-bottom: 0;
+  white-space: nowrap;
 }
 nav ul {
   list-style: none;


### PR DESCRIPTION
## Summary
- prevent `Iron Vest` from wrapping by using `white-space: nowrap` on the logo
- ensure brand uses non-breaking space in hero heading and footer

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6887683db1088330984877ad578a516c