### PR TITLE
Add gallery section and sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,14 @@
       <h2>Our Mission</h2>
       <p>Our mission is to empower teams with intelligent tools to drive strategic decisions.</p>
     </section>
+    <section class="gallery_container__C8eB1 gallery_twoRowsGrid__7Xmm9 gallery_tabletColumns__cGLny">
+      <img src="https://via.placeholder.com/600x400?text=Image+1" alt="Gallery image 1">
+      <img src="https://via.placeholder.com/600x400?text=Image+2" alt="Gallery image 2">
+      <img src="https://via.placeholder.com/600x400?text=Image+3" alt="Gallery image 3">
+      <img src="https://via.placeholder.com/600x400?text=Image+4" alt="Gallery image 4">
+      <img src="https://via.placeholder.com/600x400?text=Image+5" alt="Gallery image 5">
+      <img src="https://via.placeholder.com/600x400?text=Image+6" alt="Gallery image 6">
+    </section>
   </main>
   <footer class="site-footer">
     <div class="container">

--- a/style.css
+++ b/style.css
@@ -17,6 +17,9 @@ body {
 nav {
   background-color: #1f1f1f;
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 nav .container {
   padding: 1rem;
@@ -211,4 +214,29 @@ h2 {
     margin: 1rem auto;
     padding: 0 1rem;
   }
+}
+
+/* Gallery layout inspired by Framer's Landio template */
+.gallery_container__C8eB1 {
+  display: grid;
+  gap: 1rem;
+  margin: 2rem auto;
+  max-width: 1200px;
+}
+.gallery_twoRowsGrid__7Xmm9 {
+  grid-auto-rows: 1fr;
+}
+.gallery_tabletColumns__cGLny {
+  grid-template-columns: repeat(4, 1fr);
+}
+@media (max-width: 768px) {
+  .gallery_tabletColumns__cGLny {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.gallery_container__C8eB1 img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- make the nav bar sticky so it stays visible while scrolling
- add a new gallery section on the home page with placeholders
- style the gallery with new CSS classes inspired by Framer's Landio template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688781ecc0f88330955bcbef8d58f65f