### PR TITLE
Add sticky site title and collapsible sidebar

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/data-collection/index.html
+++ b/data-collection/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/data-collection/ingest-structured-data.html
+++ b/data-collection/ingest-structured-data.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/data-collection/ingest-unstructured-data.html
+++ b/data-collection/ingest-unstructured-data.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/data-collection/scrape-websites.html
+++ b/data-collection/scrape-websites.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/financial-modeling/create-financial-forecasts.html
+++ b/financial-modeling/create-financial-forecasts.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/financial-modeling/forecast-kpis.html
+++ b/financial-modeling/forecast-kpis.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/financial-modeling/index.html
+++ b/financial-modeling/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/fundamental-analysis/create-basic-research.html
+++ b/fundamental-analysis/create-basic-research.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/fundamental-analysis/index.html
+++ b/fundamental-analysis/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/fundamental-analysis/read-news.html
+++ b/fundamental-analysis/read-news.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/fundamental-analysis/summarize-views.html
+++ b/fundamental-analysis/summarize-views.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <nav class="index-nav">
     <div class="container">
       <a class="logo" href="index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
       <ul class="main-menu">
         <li><a href="dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
         <li><a href="user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/menu.js
+++ b/menu.js
@@ -9,4 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
       parent.classList.toggle('open');
     });
   });
+
+  const toggleBtn = document.getElementById('toggle-nav');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      document.querySelector('nav.index-nav').classList.toggle('collapsed');
+      document.body.classList.toggle('collapsed-nav');
+    });
+  }
 });

--- a/performance-analysis/analyze-trends.html
+++ b/performance-analysis/analyze-trends.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/performance-analysis/index.html
+++ b/performance-analysis/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/performance-analysis/run-performance-attribution.html
+++ b/performance-analysis/run-performance-attribution.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/portfolio-construction/analyze-current-portfolio.html
+++ b/portfolio-construction/analyze-current-portfolio.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/portfolio-construction/apply-investment-philosophy.html
+++ b/portfolio-construction/apply-investment-philosophy.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/portfolio-construction/index.html
+++ b/portfolio-construction/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/portfolio-construction/optimize-portfolio.html
+++ b/portfolio-construction/optimize-portfolio.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/create-models.html
+++ b/quantitative-analysis/create-models.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/find-factors.html
+++ b/quantitative-analysis/find-factors.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/index.html
+++ b/quantitative-analysis/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/predict-returns.html
+++ b/quantitative-analysis/predict-returns.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/screen-stocks.html
+++ b/quantitative-analysis/screen-stocks.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/quantitative-analysis/test-factors.html
+++ b/quantitative-analysis/test-factors.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/risk-management/challenge-portfolio.html
+++ b/risk-management/challenge-portfolio.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/risk-management/index.html
+++ b/risk-management/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/risk-management/provide-bear-case.html
+++ b/risk-management/provide-bear-case.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/style.css
+++ b/style.css
@@ -137,6 +137,41 @@ nav.index-nav ul li ul.submenu {
   margin-left: 1rem;
 }
 
+nav.index-nav button.toggle-nav {
+  background: none;
+  border: none;
+  color: #e5e5e5;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+nav.index-nav.collapsed {
+  width: 60px;
+}
+
+body.collapsed-nav {
+  margin-left: 60px;
+}
+
+nav.index-nav.collapsed .container {
+  align-items: center;
+}
+
+nav.index-nav.collapsed .main-menu li a {
+  font-size: 0;
+  justify-content: center;
+  padding: 0.5rem 0;
+}
+
+nav.index-nav.collapsed .main-menu li a i {
+  font-size: 1.25rem;
+  margin-right: 0;
+}
+
+nav.index-nav.collapsed ul.submenu {
+  display: none;
+}
+
 main {
   max-width: 800px;
   margin: 2rem auto;
@@ -154,10 +189,15 @@ h2 {
 }
 
 .site-title {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  background-color: #111;
   text-align: center;
   font-size: 1.75rem;
   font-weight: bold;
   margin: 1rem 0;
+  padding: 0.5rem 0;
 }
 @media (max-width: 600px) {
   nav .container {

--- a/trading/determine-market-impact.html
+++ b/trading/determine-market-impact.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/trading/index.html
+++ b/trading/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/trading/optimize-trading-schedule.html
+++ b/trading/optimize-trading-schedule.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/trading/source-liquidity.html
+++ b/trading/source-liquidity.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>

--- a/user-management/index.html
+++ b/user-management/index.html
@@ -10,6 +10,7 @@
 <nav class="index-nav">
   <div class="container">
     <a class="logo" href="../index.html"><img src="https://upload.wikimedia.org/wikipedia/en/4/43/AllianceBernstein_logo.svg" alt="AllianceBernstein logo"></a>
+        <button id="toggle-nav" class="toggle-nav"><i class="fa-solid fa-bars"></i></button>
     <ul class="main-menu">
       <li><a href="../dashboard/index.html"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
       <li><a href="../user-management/index.html"><i class="fa-solid fa-users"></i> User Management</a></li>


### PR DESCRIPTION
## Summary
- keep site title fixed at top
- add toggle button for sidebar
- update styles and script for collapsible sidebar

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887a459b83883308b2d84883192f572