### PR TITLE
Improve sidebar collapse behavior

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('nav.index-nav .main-menu li > a').forEach(a => {
+    const text = a.textContent.trim();
+    a.setAttribute('data-tooltip', text);
+    a.setAttribute('title', text);
+  });
   document.querySelectorAll('li.has-submenu > a').forEach(anchor => {
     anchor.addEventListener('click', event => {
       const parent = anchor.parentElement;

--- a/style.css
+++ b/style.css
@@ -147,6 +147,11 @@ nav.index-nav button.toggle-nav {
 
 nav.index-nav.collapsed {
   width: 60px;
+  overflow: visible; /* allow logo to keep its size */
+}
+
+nav.index-nav.collapsed a.logo img {
+  width: 180px;
 }
 
 body.collapsed-nav {
@@ -168,8 +173,44 @@ nav.index-nav.collapsed .main-menu li a i {
   margin-right: 0;
 }
 
+nav.index-nav.collapsed .main-menu li {
+  position: relative;
+}
+
 nav.index-nav.collapsed ul.submenu {
   display: none;
+  position: absolute;
+  left: 100%;
+  top: 0;
+  background-color: rgba(31, 31, 31, 0.95);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  list-style-position: inside;
+}
+
+nav.index-nav.collapsed li.open > ul.submenu {
+  display: flex;
+  flex-direction: column;
+}
+
+nav.index-nav.collapsed .main-menu li a::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 70px;
+  background: #333;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translateX(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+nav.index-nav.collapsed .main-menu li a:hover::after {
+  opacity: 1;
+  transform: translateX(0);
 }
 
 main {


### PR DESCRIPTION
## Summary
- keep logo size when sidebar is collapsed
- show tooltips on collapsed menu items
- allow submenu popouts in collapsed state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a70c734483309aa49d0809c8dd5a