### PR TITLE
Fix collapsed menu tooltip

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,13 +162,13 @@ nav.index-nav.collapsed .container {
   align-items: center;
 }
 
-nav.index-nav.collapsed .main-menu li a {
+nav.index-nav.collapsed .main-menu > li > a {
   font-size: 0;
   justify-content: center;
   padding: 0.5rem 0;
 }
 
-nav.index-nav.collapsed .main-menu li a i {
+nav.index-nav.collapsed .main-menu > li > a i {
   font-size: 1.25rem;
   margin-right: 0;
 }
@@ -199,6 +199,7 @@ nav.index-nav.collapsed .main-menu li a::after {
   left: 70px;
   background: #333;
   color: #fff;
+  font-size: 0.875rem;
   padding: 2px 6px;
   border-radius: 4px;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- keep submenu font size in collapsed nav state
- enlarge collapsed nav tooltip text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a8e86c708330bbb380513775095d