### PR TITLE
Fix logo size when sidebar collapsed

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,6 +152,7 @@ nav.index-nav.collapsed {
 
 nav.index-nav.collapsed a.logo img {
   width: 180px;
+  max-width: none;
 }
 
 body.collapsed-nav {


### PR DESCRIPTION
## Summary
- make sure the logo keeps its intended size when the sidebar is collapsed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ac62205c833099c22a6c75a2a050