### PR TITLE
Fix submenu tooltips and collapsed nav issues

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('nav.index-nav .main-menu li > a').forEach(a => {
+  // Apply tooltips only for top-level menu items
+  document.querySelectorAll('nav.index-nav .main-menu > li > a').forEach(a => {
     const text = a.textContent.trim();
     a.setAttribute('data-tooltip', text);
     a.setAttribute('title', text);
@@ -28,16 +29,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const nav = document.querySelector('nav.index-nav');
   if (nav) {
-    // start with the navigation collapsed
-    nav.classList.add('collapsed');
-    document.body.classList.add('collapsed-nav');
+    // Restore previous nav state if available
+    const collapsedStored = localStorage.getItem('navCollapsed') === 'true';
+    nav.classList.toggle('collapsed', collapsedStored);
+    document.body.classList.toggle('collapsed-nav', collapsedStored);
   }
 
   const toggleBtn = document.getElementById('toggle-nav');
   if (toggleBtn) {
     toggleBtn.addEventListener('click', () => {
-      nav.classList.toggle('collapsed');
-      document.body.classList.toggle('collapsed-nav');
+      const collapsed = nav.classList.toggle('collapsed');
+      document.body.classList.toggle('collapsed-nav', collapsed);
+      localStorage.setItem('navCollapsed', collapsed);
     });
   }
 });

--- a/style.css
+++ b/style.css
@@ -184,11 +184,13 @@ nav.index-nav.collapsed .main-menu li {
 nav.index-nav.collapsed ul.submenu {
   display: none;
   position: absolute;
-  left: 100%;
-  top: 0;
+  left: 0;
+  top: 100%;
+  min-width: 180px;
   background-color: rgba(31, 31, 31, 0.95);
   padding: 0.5rem 1rem;
   border-radius: 4px;
+  z-index: 1000;
   list-style-position: inside;
 }
 


### PR DESCRIPTION
## Summary
- show tooltips only on top‑level menu items
- remember collapsed state of the side navigation
- update collapsed menu CSS so submenus drop below the icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b3ff77748330b21418aea1b59c92