### PR TITLE
Hide toggle button

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,6 +147,8 @@ nav.index-nav button.toggle-nav {
   color: #e5e5e5;
   cursor: pointer;
   font-size: 1.25rem;
+  /* Hide the toggle button for now */
+  display: none;
 }
 
 nav.index-nav.collapsed {


### PR DESCRIPTION
## Summary
- hide the navigation toggle button so it doesn't show up on pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b64a9ee88330b0b6360f7d4725b0