### PR TITLE
Update gallery to use local images with two-column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,12 +96,12 @@
       <p>Our mission is to empower teams with intelligent tools to drive strategic decisions.</p>
     </section>
     <section class="gallery_container__C8eB1 gallery_twoRowsGrid__7Xmm9 gallery_tabletColumns__cGLny">
-      <img src="https://via.placeholder.com/600x400?text=Image+1" alt="Gallery image 1">
-      <img src="https://via.placeholder.com/600x400?text=Image+2" alt="Gallery image 2">
-      <img src="https://via.placeholder.com/600x400?text=Image+3" alt="Gallery image 3">
-      <img src="https://via.placeholder.com/600x400?text=Image+4" alt="Gallery image 4">
-      <img src="https://via.placeholder.com/600x400?text=Image+5" alt="Gallery image 5">
-      <img src="https://via.placeholder.com/600x400?text=Image+6" alt="Gallery image 6">
+      <img src="images/img1.png" alt="Gallery image 1">
+      <img src="images/img2.png" alt="Gallery image 2">
+      <img src="images/img3.png" alt="Gallery image 3">
+      <img src="images/img4.png" alt="Gallery image 4">
+      <img src="images/img5.png" alt="Gallery image 5">
+      <img src="images/img6.png" alt="Gallery image 6">
     </section>
   </main>
   <footer class="site-footer">

--- a/style.css
+++ b/style.css
@@ -360,12 +360,7 @@ h2 {
   grid-auto-rows: 1fr;
 }
 .gallery_tabletColumns__cGLny {
-  grid-template-columns: repeat(4, 1fr);
-}
-@media (max-width: 768px) {
-  .gallery_tabletColumns__cGLny {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(2, 1fr);
 }
 .gallery_container__C8eB1 img {
   width: 100%;


### PR DESCRIPTION
## Summary
- swap placeholder images with images from the `images` folder
- simplify gallery grid to always use two columns

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888916088e48330ba313a3f3794fed9