### PR TITLE
Fix gallery layout for 2 images per row

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,7 +355,7 @@ h2 {
   gap: 1rem;
   margin: 2rem auto;
   width: 100%;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
 }
 .gallery_twoRowsGrid__7Xmm9 {
   grid-auto-rows: 1fr;


### PR DESCRIPTION
## Summary
- update gallery layout CSS to always show exactly two images per row

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888c05ad4ec8330a0454a8c62633cfd